### PR TITLE
Add build_args to create_local_image and get_dockerfile_build_cmd.

### DIFF
--- a/src/BuildDockerfile.jl
+++ b/src/BuildDockerfile.jl
@@ -112,8 +112,10 @@ function get_dockerfile_build_cmd(
     dockerfile::String,
     image_full_name_plus_tag::String,
     no_cache::Bool,
+    build_args::Vector{Pair}
   )::Cmd
   options = ["--rm", "--iidfile", "id", "--tag", "$image_full_name_plus_tag"]
+  [push!(options, e) for e in map(x -> [first(x), last(x)], build_args) |> x -> reduce(vcat, x)]
   no_cache && push!(options, "--no-cache")
   `docker build $options .`
 end


### PR DESCRIPTION
This is concise at the expense of clarity, but it does the job. For example:

```julia
pairs = [Pair("--build-arg", "arg1"), Pair("--build-arg", "arg2")];
options = ["--rm", "--iidfile", "id", "--tag"];

[push!(options, e) for e in map(x -> [first(x), last(x)], pairs) |> x -> reduce(vcat, x)];

options
# 8-element Vector{String}:
#  "--rm"
#  "--iidfile"
#  "id"
#  "--tag"
#  "--build-arg"
#  "arg1"
#  "--build-arg"
#  "arg2"
```